### PR TITLE
Added field name conflict resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,4 @@ Use `xsd-isogen in.xsd Parser > out.hs` for responses.
 
 Use `xsd-isogen in.xsd Both > out.hs` for common definitions.
 
-Keep in mind that name clashes are possible and should be disambiguated
-manually. If you have a good idea how to handle that, feel free to create an
-issue and/or PR. Module name for all auto-generated files is set to `module
-Dummy where`, so it should be updated appropriately as well.
+If there are conflicting field names in some datatypes, one of the the datatype names gets consecutive numbers starting from 2 appended to it (so that the field name prefix changes) until there are no more conflicts.


### PR DESCRIPTION
Added field name conflict resolution

The method of resolution is as follows:

If any two datatypes with the same name abbreviation ('makeNamePrefix')
have any fields in common, then one of them gets a \"2\" appended to it
(\"_2\" if the last character of the name was a digit).
Repeat the same process until there are no conflicts.
If we have already appended a \"2\" to a datatype and it still has conflicts,
we change the 2 to a 3, a 3 to a 4 and so on.

I extracted some functions to make prefix creation and enum detection consistent across the project.