### PR TITLE
Nillable types

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,4 +3,4 @@ packages: .
 source-repository-package
       type:     git
       location: https://github.com/typeable/xsd-parser.git
-      tag: a4402933fcdba6648b91b3f1e8d85a9c327c26e7
+      tag: be6f2e92d3c6b381922957fa51821e8e57840da3

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -324,13 +324,18 @@ genField typeName e = do
 
   qualifier <- makeQualifier (Xsd.elementOccurs e)
 
+  let
+    fieldType = if Xsd.elementNillable e
+      then "Nillable " <> fieldTypeName
+      else fieldTypeName
+
   return $ Just $ mconcat
     [ "  "
     , qualifier
     , " \""
     , fieldName
     , "\" [t|"
-    , fieldTypeName
+    , fieldType
     , "|]"
     ]
 


### PR DESCRIPTION
For fields that have `nillable=true` attribute set, we use `Nillable` wrapper.