### PR TITLE
Generate catch-all clause in fromDom for extensions

### DIFF
--- a/golden/extension.xsd.hs
+++ b/golden/extension.xsd.hs
@@ -51,7 +51,7 @@ instance FromDom AnyXmlBasetype where
       "Basetype" -> TheXmlBasetype <$> fromDom
       "Ext2" -> TheXmlExt2 <$> fromDom
       "Ext1" -> TheXmlExt1 <$> fromDom
-      _ -> fail "unexpected type"
+      _ -> throwParserError (PEOther "unexpected type")
 
 instance ToXML AnyXmlBasetype where
   toXML (TheXmlBasetype a) = toXML a

--- a/golden/extension.xsd.hs
+++ b/golden/extension.xsd.hs
@@ -51,7 +51,7 @@ instance FromDom AnyXmlBasetype where
       "Basetype" -> TheXmlBasetype <$> fromDom
       "Ext2" -> TheXmlExt2 <$> fromDom
       "Ext1" -> TheXmlExt1 <$> fromDom
-      _ -> throwParserError (PEOther "unexpected type")
+      _ -> throwParserError (PEOther "Unexpected type")
 
 instance ToXML AnyXmlBasetype where
   toXML (TheXmlBasetype a) = toXML a

--- a/golden/extension.xsd.hs
+++ b/golden/extension.xsd.hs
@@ -51,6 +51,7 @@ instance FromDom AnyXmlBasetype where
       "Basetype" -> TheXmlBasetype <$> fromDom
       "Ext2" -> TheXmlExt2 <$> fromDom
       "Ext1" -> TheXmlExt1 <$> fromDom
+      _ -> fail "unexpected type"
 
 instance ToXML AnyXmlBasetype where
   toXML (TheXmlBasetype a) = toXML a

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -139,7 +139,7 @@ genExtension base = do
         clauses <- mapM mkClause (base : map fst types)
         writeCode clauses
         writeCode
-          [ "      _ -> throwParserError (PEOther \"unexpected type\")"
+          [ "      _ -> throwParserError (PEOther \"Unexpected type\")"
           , ""
           ]
       unless (mode == Parser) $ do

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -138,7 +138,10 @@ genExtension base = do
               ]
         clauses <- mapM mkClause (base : map fst types)
         writeCode clauses
-        writeCode [""]
+        writeCode
+          [ "      _ -> fail \"unexpected type\""
+          , ""
+          ]
       unless (mode == Parser) $ do
         writeCode
           [ "instance ToXML Any" <> baseTypeName <> " where"

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -139,7 +139,7 @@ genExtension base = do
         clauses <- mapM mkClause (base : map fst types)
         writeCode clauses
         writeCode
-          [ "      _ -> fail \"unexpected type\""
+          [ "      _ -> throwParserError (PEOther \"unexpected type\")"
           , ""
           ]
       unless (mode == Parser) $ do


### PR DESCRIPTION
It handles the case when the type is unknown.

I somehow missed this case initially.